### PR TITLE
[f1c100s] add code for sunxi-fel to judge the execution is success

### DIFF
--- a/src/arch/arm32/mach-f1c100s/sys-copyself.c
+++ b/src/arch/arm32/mach-f1c100s/sys-copyself.c
@@ -64,6 +64,17 @@ void sys_copyself(void)
 
 	if(d == BOOT_DEVICE_FEL)
 	{
+		/* Restore eGON.FEL signature */
+		char *sig = (char *)0x4;
+		sig[0] = 'e';
+		sig[1] = 'G';
+		sig[2] = 'O';
+		sig[3] = 'N';
+		sig[4] = '.';
+		sig[5] = 'F';
+		sig[6] = 'E';
+		sig[7] = 'L';
+
 		sys_uart_putc('B');
 		sys_uart_putc('o');
 		sys_uart_putc('o');


### PR DESCRIPTION
The sunxi-fel tool will consider the execution of the SPL is correct if
a "eGON.FEL" header is found at 0x4. However in xboot it's overwritten
by the interrupt vector, so restore it when exiting to FEL.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>